### PR TITLE
README: Fix Doc Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ excellent
 
 Want to learn more? Read the
 
-⭐️ [Spackbot Documentation](https://spack.github.io/spack-bot) ⭐️
+⭐️ [Spackbot Documentation](https://spack.github.io/spackbot) ⭐️
 
 ## License
 


### PR DESCRIPTION
Fix the GH pages documentation link.

Note: do not forget to update the repo URL as well.