### PR TITLE
logging: make log level customizable

### DIFF
--- a/spackbot/__main__.py
+++ b/spackbot/__main__.py
@@ -17,7 +17,8 @@ from .auth import authenticate_installation
 # take environment variables from .env file (if present)
 load_dotenv()
 
-logging.basicConfig(level=logging.INFO)
+log_level = os.environ.get("LOGLEVEL", "INFO").upper()
+logging.basicConfig(level=log_level)
 logger = logging.getLogger("spackbot")
 
 #: Location for authenticatd app to get a token for one of its installations


### PR DESCRIPTION
This adds the ability to set the log level from an environment variable:

```python
log_level = os.environ.get("LOGLEVEL", "INFO").upper()
logging.basicConfig(level=log_level)
```