### PR TITLE
URL encode branch names in case of reserved chars

### DIFF
--- a/spackbot/handlers/pipelines.py
+++ b/spackbot/handlers/pipelines.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import urllib.parse
 import spackbot.helpers as helpers
 
 import aiohttp
@@ -50,6 +51,7 @@ async def run_pipeline(event, gh):
     # We need the branch name plus number to assemble the GitLab CI
     branch = pr["head"]["ref"]
     branch = f"github/pr{number}_{branch}"
+    branch = urllib.parse.quote_plus(branch)
 
     url = f"{helpers.gitlab_spack_project_url}/pipeline?ref={branch}"
     headers = {"PRIVATE-TOKEN": GITLAB_TOKEN}


### PR DESCRIPTION
Based on some local testing, making gitlab api requests using urls with reserved characters like `+` results in failure, while using urllib to encode the branch names first results in success.  Hopefully this change will fix issues reported with spackbot responding "I had a problem triggering the pipeline", as seen on this spack [PR](https://github.com/spack/spack/pull/25821).