### PR TITLE
workers: Do not attempt to re-auth installation

### DIFF
--- a/spackbot/__main__.py
+++ b/spackbot/__main__.py
@@ -44,7 +44,6 @@ async def main(request):
     token = await authenticate_installation(installation_id)
 
     dispatch_kwargs = {
-        "installation_id": installation_id,
         "token": token,
     }
 

--- a/spackbot/handlers/style.py
+++ b/spackbot/handlers/style.py
@@ -38,26 +38,17 @@ async def fix_style(event, gh, *args, **kwargs):
     """
     Respond to a request to fix style by placing a task in the work queue
     """
-    installation_id = None
-
-    if "installation_id" in kwargs:
-        installation_id = kwargs["installation_id"]
-
     job_metadata = {
-        # This object is attached to job, so we can e.g. access from within the
-        # job's on_failure callback.
+        # This object is attached to job, so we can access it from within the
+        # job's on_failure callback or from the job itself.
         "post_comments_url": event.data["issue"]["comments_url"],
-        "token": None,
+        "token": kwargs["token"],
     }
-
-    if "token" in kwargs:
-        job_metadata["token"] = kwargs["token"]
 
     task_q = work_queue.get_queue()
     fix_style_job = task_q.enqueue(
         fix_style_task,
         event,
-        installation_id,
         job_timeout=WORKER_JOB_TIMEOUT,
         meta=job_metadata,
         on_failure=report_style_failure,


### PR DESCRIPTION
According to the ghapi docs, the token should be good for one hour
from the time you request.  So instead of having the worker attempt
to re-authenticate the installation as soon as it starts (which so
far has been pretty much immediately), let's just use the token we
already put in the job metadata to communicate with the api.

If we ever see that the worker is taking more than an hour to get
kicked off or do it'w work, we can revisit this.