### PR TITLE
labels: dedup labels before posting

### DIFF
--- a/spackbot/handlers/labels.py
+++ b/spackbot/handlers/labels.py
@@ -144,7 +144,7 @@ async def add_labels(event, gh):
 
     # Iterate over modified files and create a list of labels
     # https://developer.github.com/v3/pulls/#list-pull-requests-files
-    labels = []
+    labels = set()
     async for file in gh.getiter(pull_request["url"] + "/files"):
         filename = file["filename"]
         status = file["status"]
@@ -177,10 +177,10 @@ async def add_labels(event, gh):
                 )
             # If all attributes have at least one pattern match, we add the label
             if all(attr_matches):
-                labels.append(label)
+                labels.add(label)
 
     logger.info(f"Adding the following labels: {labels}")
 
     # https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
     if labels:
-        await gh.post(pull_request["issue_url"] + "/labels", data=labels)
+        await gh.post(pull_request["issue_url"] + "/labels", data=list(labels))


### PR DESCRIPTION
Noticed in logs that we sometimes fail to apply labels due to a bug where we post a lot of duplicates.  Here's an example from a recent log file:

```
INFO:spackbot.handlers.labels:Adding the following labels: ['update-package', 'update-package', 'maintainers', 'new-version', 'patch', 'update-package', 'maintainers', 'new-version', ..., 'new-version']
ERROR:aiohttp.server:Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 435, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/app/spackbot/__main__.py", line 54, in main
    await router.dispatch(event, gh, session=session, **dispatch_kwargs)
  File "/app/spackbot/routes.py", line 42, in dispatch
    await callback(event, *args, **kwargs)
  File "/app/spackbot/routes.py", line 124, in label_pull_requests
    await handlers.add_labels(event, gh)
  File "/app/spackbot/handlers/labels.py", line 186, in add_labels
    await gh.post(pull_request["issue_url"] + "/labels", data=labels)
  File "/usr/local/lib/python3.7/site-packages/gidgethub/abc.py", line 191, in post
    content_type=content_type,
  File "/usr/local/lib/python3.7/site-packages/gidgethub/abc.py", line 117, in _make_request
    data, self.rate_limit, more = sansio.decipher_response(*response)
  File "/usr/local/lib/python3.7/site-packages/gidgethub/sansio.py", line 365, in decipher_response
    raise exc_type(errors, message)
gidgethub.InvalidField: Validation Failed. Issues cannot have more than 100 labels for 'labels'
```

This change makes sure we post a unique set of labels to each new PR.