### PR TITLE
Customizable queue name

### DIFF
--- a/.env-dummy
+++ b/.env-dummy
@@ -7,6 +7,9 @@ REDIS_HOST=rq-server
 # Optionally customize redis port
 REDIS_PORT=6379
 
+# Optionally customize the name of the task queue
+TASK_QUEUE_NAME=devtasks
+
 # Optionally configure time before jobs are killed and marked failed (in seconds, default 180s)
 WORKER_JOB_TIMEOUT=21600
 

--- a/spackbot/routes.py
+++ b/spackbot/routes.py
@@ -54,8 +54,11 @@ async def add_style_comments(event, gh, *args, session, **kwargs):
     if event.data["check_run"]["conclusion"] == "success":
         return
 
+    check_name = event.data["check_run"]["name"]
+    logger.info(f"check run {check_name} unsuccesful")
+
     # If it's not a style check, we don't care
-    if event.data["check_run"]["name"] == "style":
+    if check_name == "style":
         await handlers.style_comment(event, gh)
 
 

--- a/spackbot/workers.py
+++ b/spackbot/workers.py
@@ -17,6 +17,7 @@ logger = helpers.get_logger(__name__)
 
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
+TASK_QUEUE_NAME = os.environ.get("TASK_QUEUE_NAME", "tasks")
 
 
 class WorkQueue:
@@ -24,7 +25,7 @@ class WorkQueue:
         logger.info(f"WorkQueue creating redis connection ({REDIS_HOST}, {REDIS_PORT})")
         self.redis_conn = Redis(host=REDIS_HOST, port=REDIS_PORT)
         # Name of queue workers use is defined in "workers/entrypoint.sh"
-        self.task_q = Queue(name="tasks", connection=self.redis_conn)
+        self.task_q = Queue(name=TASK_QUEUE_NAME, connection=self.redis_conn)
 
     def get_queue(self):
         return self.task_q

--- a/workers/entrypoint.sh
+++ b/workers/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-# Define REDIS_HOST and REDIS_PORT in .env file or k8s deployment.  The queue
-# from which workers take jobs is given the name "tasks" here.
-rq worker -u redis://${REDIS_HOST}:${REDIS_PORT} --with-scheduler tasks
+# Define REDIS_HOST, REDIS_PORT and TASK_QUEUE_NAME in .env file or k8s
+# deployment.  REDIS_HOST and REDIS_PORT define the hostname/ip and port
+# of the redis instance, while TASK_QUEUE_NAME defines the name of the
+# queue used for communication between the webservice and workers.
+rq worker -u redis://${REDIS_HOST}:${REDIS_PORT} --with-scheduler ${TASK_QUEUE_NAME}


### PR DESCRIPTION
Without this, and considering we had only a single redis instance backing both the production and development deployments, it was arbitrary which deployment would pick up enqueued tasks (dev vs production).  So a worker from the dev deployment would randomly pick up a task enqueued by the production spackbot webservice, or vice versa, and in this case it would not have any of the correct secrets to successfully complete the job.  This change makes the queue name an environment variable so the two deployment environments can use distinct work queues in the same redis instance.