### PR TITLE
Block running pipeline if it would test an old commit

### DIFF
--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -192,6 +192,16 @@ async def post(url, headers):
             return await response.json()
 
 
+async def get(url, headers):
+    """
+    Convenience method to create a new session and make a one-off
+    get request, given a url and headers to include in the request.
+    """
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers) as response:
+            return await response.json()
+
+
 async def delete(url, headers):
     """
     Convenience method to create a new session and make a one-off


### PR DESCRIPTION
If gitlab does not have the latest code from a PR on github, then spackbot should not allow the developer to run a pipeline, and it should instead respond with a message indicating why it cannot comply

This PR accomplishes that by first hitting gitlab's commits [endpoint](https://docs.gitlab.com/ee/api/commits.html#list-repository-commits), and comparing to make sure one of the `parent_ids` in the response matches the value in the `head->sha` returned by the github api [request](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request).  If gitlab does not have the developer's latest code, it will now post the following comment in response to the pipeline request:

```
I'm sorry, gitlab does not have your latest revision yet, I can't run that pipeline for you right now.
```

This should help in the short term, while the gh-gl-sync cron job is still managing pushing branches from github to gitlab for testing, but it should still be effective after we begin holding back PRs until they're based behind latest tested develop.