### PR TITLE
Add black and clingo to the list of preinstalled packages

### DIFF
--- a/workers/requirements.txt
+++ b/workers/requirements.txt
@@ -9,3 +9,5 @@ sh
 mypy
 flake8
 isort
+black
+clingo


### PR DESCRIPTION
I confirm `spackbot fix style` doesn't work currently. My working hypothesis is that we might be installing some conflicting Python package in this image, since spack now appends to `sys.path`.

I'll check that out, but reading through `requirements.txt` I am pretty sure we were installing black all the time - which now also installs all the other three. Submitting this fix under the assumption that is not an issue to build and deploy this image regularly (or on demand) but let me know if this is not the case and we should seek another fix.