### PR TITLE
black 23 formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           message: 'Please format your code with [black](https://black.readthedocs.io): `black spackbot`.'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       # TODO add tests here?

--- a/spackbot/handlers/reviewers.py
+++ b/spackbot/handlers/reviewers.py
@@ -116,7 +116,6 @@ async def add_issue_maintainers(event, gh, package_list):
 
     # If we match a package in the title, look for maintainers to ping
     if packages:
-
         # Remove extra spacing that helped search
         packages = [x.strip() for x in packages]
 
@@ -130,7 +129,6 @@ async def add_issue_maintainers(event, gh, package_list):
             from sh import spack
 
             for package in packages:
-
                 # Query maintainers from develop
                 found_maintainers = spack(
                     "maintainers", package, _ok_code=(0, 1)

--- a/spackbot/handlers/style.py
+++ b/spackbot/handlers/style.py
@@ -28,7 +28,6 @@ async def style_comment(event, gh):
     repository = event.data["repository"]["full_name"]  # "spack-test/spack"
     for pr in event.data["check_run"]["pull_requests"]:  # []
         if repository in pr["url"]:
-
             number = pr["url"].split("/")[-1]
             comments_url = (
                 f"https://api.github.com/repos/{repository}/issues/{number}/comments"

--- a/spackbot/workers.py
+++ b/spackbot/workers.py
@@ -304,7 +304,6 @@ async def fix_style_task(event):
 
         # At this point, we can clone the repository and make the change
         with helpers.temp_dir() as cwd:
-
             # Clone a fresh spack develop to use for spack style
             git.clone(helpers.spack_upstream, "spack-develop")
 


### PR DESCRIPTION
#73 is failing because the new black 23 release adds new formatting changes. This PR updates the whole repo with the new style.

We could pin black to a specific version like @alalazo did if we want more stability, but traffic for this repo is small enough that I don't think it really matters.