### PR TITLE
Fix regex for detection of reviewers

### DIFF
--- a/spackbot/handlers/reviewers.py
+++ b/spackbot/handlers/reviewers.py
@@ -32,7 +32,7 @@ async def parse_maintainers_from_patch(gh, pull_request):
         pkg = re.search(r"/([^/]+)/package.py", filename).group(1)
 
         code = file["patch"]
-        arrays = re.findall(r"maintainers(\(|\s*=\s*\[)[^\]\)]*(\)|\])", code)
+        arrays = re.findall(r"maintainers(?:\(|\s*=\s*\[)[^\]\)]*(?:\)|\])", code)
         for array in arrays:
             file_maintainers = re.findall("['\"][^'\"]*['\"]", array)
             for m in file_maintainers:


### PR DESCRIPTION
Fixes a bug I introduced in #73.

### Before #73

Only the old syntax was detected properly:
```pycon
>>> import re
>>> old = 'maintainers = ["a", "bc", "d"]'
>>> new = 'maintainers("a", "bc", "d")'
>>> re.findall(r"maintainers\s*=\s*\[[^\]]*\]", old)
['maintainers = ["a", "bc", "d"]']
>>> re.findall(r"maintainers\s*=\s*\[[^\]]*\]", new)
[]
```

### After #73 

Neither worked 😅 
```pycon
>>> re.findall(r"maintainers(\(|\s*=\s*\[)[^\]\)]*(\)|\])", old)
[(' = [', ']')]
>>> re.findall(r"maintainers(\(|\s*=\s*\[)[^\]\)]*(\)|\])", new)
[('(', ')')]
```

### After this PR

Both work:
```pycon
>>> re.findall(r"maintainers(?:\(|\s*=\s*\[)[^\]\)]*(?:\)|\])", old)
['maintainers = ["a", "bc", "d"]']
>>> re.findall(r"maintainers(?:\(|\s*=\s*\[)[^\]\)]*(?:\)|\])", new)
['maintainers("a", "bc", "d")']
```

The regex below it does not require updating:
```pycon
>>> re.findall("['\"][^'\"]*['\"]", old)
['"a"', '"bc"', '"d"']
>>> re.findall("['\"][^'\"]*['\"]", new)
['"a"', '"bc"', '"d"']
```