### PR TITLE
Remove github-actions broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ option.
 All new contributions must be made under both the MIT and Apache-2.0
 licenses.
 
-See [LICENSE-MIT](https://github.com/spack/spack-bot/blob/master/LICENSE-MIT),
-[LICENSE-APACHE](https://github.com/spack/spack-bot/blob/master/LICENSE-APACHE),
-[COPYRIGHT](https://github.com/spack/spack-bot/blob/master/COPYRIGHT), and
-[NOTICE](https://github.com/spack/spack-bot/blob/master/NOTICE) for details.
+See [LICENSE-MIT](https://github.com/spack/spackbot/blob/master/LICENSE-MIT),
+[LICENSE-APACHE](https://github.com/spack/spackbot/blob/master/LICENSE-APACHE),
+[COPYRIGHT](https://github.com/spack/spackbot/blob/master/COPYRIGHT), and
+[NOTICE](https://github.com/spack/spackbot/blob/master/NOTICE) for details.
 
 SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -11,7 +11,7 @@ Hi I'm spackbot! 👋  I can help you with [spack](https://github.com/spack/spac
 - [Packages](#packages)
 
 ## Quick Start
- 
+
 Here are some quick commands to get you started, and you can check out more detailed [developer guide](developer-guide/developer-guide) or [user guide](user-guide/user-guide). There are several different was you might want to interact with me, and other ways I will interact with you!
 
 ### Say hello
@@ -57,7 +57,7 @@ Don't you love GitHub labels? I do! Whenever you open a pull request, I'll take 
 Are you opening a pull request for a package? I'll help to find and ping maintainers for it! And if there aren't any, I'll start a discussion to figure out who might be able to do it.
 
 And I just might have some other commands and jokes up my sleeve! Want to learn more? Browse the links on the left navigation, or
-<a href="https://github.com/spack/spack-bot" target="_blank">ask me a question</a>. Thanks for stopping by! 😉
+<a href="https://github.com/spack/spackbot" target="_blank">ask me a question</a>. Thanks for stopping by! 😉
 
 ### Packages
 

--- a/docs/docs/developer-guide/developer-guide.md
+++ b/docs/docs/developer-guide/developer-guide.md
@@ -9,6 +9,6 @@
 ## Hey there!
 
 Thanks for your interest in developing for Spackbot! You can read more about the development
-process in the links above, or [check out spackbot's issue board](https://github.com/spack/spack-bot/issues)
+process in the links above, or [check out spackbot's issue board](https://github.com/spack/spackbot/issues)
 to ask a question or see if there is anything you can help with.
 

--- a/docs/docs/developer-guide/docker-compose.md
+++ b/docs/docs/developer-guide/docker-compose.md
@@ -31,9 +31,9 @@ The other secrets we will populate after we register the app, discussed next.
 You should next register a [GitHub App](https://github.com/settings/apps) under your username.
 You'll first need to create a  [Follow this link](https://github.com/settings/apps) and click "New GitHub App."
 
-#### Create 
+#### Create
  - **GitHub App Name**: can be whatever you like, SpackBot Develop for example.
- - **Homepage URL**: you can put the repository here, https://github.com/spack/spack-bot
+ - **Homepage URL**: you can put the repository here, https://github.com/spack/spackbot
  - You don't need to identify or authorize users.
  - **Webhook URL** enter your smee url
  - **Repo Permissions** You want to add:
@@ -56,9 +56,9 @@ You'll first need to create a  [Follow this link](https://github.com/settings/ap
    - deployment status
  - It's safer to select to run only on your user account.
 
-#### Post Create 
+#### Post Create
 After you create the App you will be redirected to a screen that has the app ID and
-secrets. Make a private key, and copy it to the [spackbot](https://github.com/spack/spack-bot/tree/main/spackbot) directory
+secrets. Make a private key, and copy it to the [spackbot](https://github.com/spack/spackbot/tree/main/spackbot) directory
 for the app to see, named as `spack-bot-develop.private-key.pem`.
 
 ```bash
@@ -81,7 +81,7 @@ In order for spackbot to be able to push to pull requests (and otherwise have wr
 you'll need to provide credentials to the server associated with a GitHub bot account (e.g., [spackbot](https://github.com/spackbot))
 and then bind them to the container here for use. If you are unable to do this, you should comment
 out the volume in the `docker-compose.yml` (and assume that style fixes, rebases, and similar commands that require
-write will not work). 
+write will not work).
 
 ```yaml
 volumes:
@@ -147,7 +147,7 @@ spackbot_1  | (Press CTRL+C to quit)
 ```
 
 Now you can develop/make changes, and then restart the containers to restart the
-server. Since [spackbot](https://github.com/spack/spack-bot/tree/main/spackbot) is bound to the app install location in the container,
+server. Since [spackbot](https://github.com/spack/spackbot/tree/main/spackbot) is bound to the app install location in the container,
 your app will update with changes.
 
 Next you would want to [install the app](install) so you can interact with a pull request
@@ -155,7 +155,7 @@ and see the result on your local server.
 
 ## 5. Organization
 
-Different events are represented in [spackbot/routes.py](https://github.com/spack/spack-bot/tree/main/spackbot/routes.py).
+Different events are represented in [spackbot/routes.py](https://github.com/spack/spackbot/tree/main/spackbot/routes.py).
 For example, there is one common entrypoint for spackbot to respond to comments,
 or the opening of a pull request, or a check run result. So you should first
 see if there is a router that already fits your purpose.
@@ -164,8 +164,8 @@ see if there is a router that already fits your purpose.
 2. If not, you can add a new router.
 
 In most complex cases, the routers pass on execution to a handler, and handlers
-are in [spackbot/handlers](https://github.com/spack/spack-bot/tree/main/spackbot/handlers). For each handler, you can write
+are in [spackbot/handlers](https://github.com/spack/spackbot/tree/main/spackbot/handlers). For each handler, you can write
 whatever functionality you need in the submodule (e.g., `handlers.style`) and
 then import the function that is needed by the router in `__init__`. Helpers
-or variables shared amongst modules should go into [helpers.py](https://github.com/spack/spack-bot/tree/main/spackbot/helpers.py),
-and comments should go into [comments.py](https://github.com/spack/spack-bot/tree/main/spackbot/comments.py).
+or variables shared amongst modules should go into [helpers.py](https://github.com/spack/spackbot/tree/main/spackbot/helpers.py),
+and comments should go into [comments.py](https://github.com/spack/spackbot/tree/main/spackbot/comments.py).

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -46,7 +46,7 @@
               <div class="side-title-item">\
                 <img src="../assets/img/spackbot.svg" width=\"150px\" /> \
               </div>',
-        repo: 'https://github.com/spack/spack-bot',
+        repo: 'https://github.com/spack/spackbot',
         auto2top: true,
         executeScript: true,
         maxLevel: 3,
@@ -58,7 +58,7 @@
         plugins: [
         function(hook, vm) {
             hook.beforeEach(function(html) {
-              url = 'https://github.com/spack/spack-bot/blob/main/' + vm.route.file;
+              url = 'https://github.com/spack/spackbot/blob/main/' + vm.route.file;
               var editHtml = '[:memo: Edit Document](' + url + ')\n';
               return (
                 editHtml +

--- a/docs/docs/support.md
+++ b/docs/docs/support.md
@@ -1,4 +1,4 @@
 # Support
 
-Do you need help? You can [open an issue](https://github.com/spack/spack-bot/issues) on the spack-bot repository, or
+Do you need help? You can [open an issue](https://github.com/spack/spackbot/issues) on the spackbot repository, or
 [join us on slack](https://slack.spack.io/) in the `#spackbot` channel.

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,8 +13,8 @@
     <meta content="Spackbot" property="og:title">
     <meta content="website" property="og:type">
     <meta content="The spack maintainer bot" property="og:description">
-    <meta content="https://spack.github.io/spack-bot" property="og:url">
-    <meta content="https://spack.github.com/spack-bot/assets/img/spackbot.png" property="og:image">
+    <meta content="https://spack.github.io/spackbot" property="og:url">
+    <meta content="https://spack.github.com/spackbot/assets/img/spackbot.png" property="og:image">
 
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary">
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="Spackbot">
     <meta name="twitter:url" content="https://spack.github.io/spackbot">
     <meta name="twitter:description" content="The spack maintainer bot">
-    <meta name="twitter:image:src" content="https://spack.github.com/spack-bot/assets/img/spackbot.png">
+    <meta name="twitter:image:src" content="https://spack.github.com/spackbot/assets/img/spackbot.png">
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="assets/img/favicon.ico" />
@@ -44,8 +44,8 @@
 
       <div class="socialLinks">
       <a class="socialLinks__link socialLInk__twitter" href="docs/">getting-started</a>
-      <a class="socialLinks__link socialLInk__github" href="https://github.com/spack/spack-bot" target="_blank">github</a>
-      <a class="socialLinks__link socialLInk__github-actions" href="https://github.com/spack/spack-bot/issues" target="_blank">support</a>
+      <a class="socialLinks__link socialLInk__github" href="https://github.com/spack/spackbot" target="_blank">github</a>
+      <a class="socialLinks__link socialLInk__github-actions" href="https://github.com/spack/spackbot/issues" target="_blank">support</a>
 </div>
 
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
-    <title>Spackbot</title> 
+    <title>Spackbot</title>
 
     <!-- Open Graph Meta -->
     <meta content="Spackbot" property="og:site_name">
@@ -37,7 +37,7 @@
 
   <main>
     <div class="half--right half__content">
-      
+
 <h1 class="pageTitle">Spackbot</h1>
 <p class="pageContent">Hi, I'm Spackbot! I'm here to help. Learn more by choosing a button below.</p>
 
@@ -45,8 +45,7 @@
       <div class="socialLinks">
       <a class="socialLinks__link socialLInk__twitter" href="docs/">getting-started</a>
       <a class="socialLinks__link socialLInk__github" href="https://github.com/spack/spack-bot" target="_blank">github</a>
-      <a class="socialLinks__link socialLInk__github-actions" href="https://github.com/apps/spack-bot" target="_blank">github-actions</a>  
-      <a class="socialLinks__link socialLInk__github-actions" href="https://github.com/spack/spack-bot/issues" target="_blank">support</a>  
+      <a class="socialLinks__link socialLInk__github-actions" href="https://github.com/spack/spack-bot/issues" target="_blank">support</a>
 </div>
 
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "spack-bot"
+name = "spackbot"
 version = "0.0.1"
 description = "Bot to automate tasks for the Spack project (https://github.com/spack/spack)"
 authors = [

--- a/spackbot/comments.py
+++ b/spackbot/comments.py
@@ -116,7 +116,7 @@ You can interact with me in many ways!
 - `{helpers.botname} maintainers` or `{helpers.botname} request review`: to look for and assign reviewers for the pull request.
 
 I'll also help to label your pull request and assign reviewers!
-If you need help or see there might be an issue with me, open an issue [here](https://github.com/spack/spack-bot/issues)
+If you need help or see there might be an issue with me, open an issue [here](https://github.com/spack/spackbot/issues)
 """
 
 style_message = f"""


### PR DESCRIPTION
The "github-actions" button on https://spack.github.io/spackbot/ is broken. I don't think https://github.com/apps/spack-bot or any permutation of that actually exists. Let's just remove the button.