### PR TITLE
Update regex for stand-alone-tests label

### DIFF
--- a/spackbot/handlers/labels.py
+++ b/spackbot/handlers/labels.py
@@ -68,7 +68,7 @@ label_patterns = {
     "external-packages": {"patch": r"[+-] +def determine_spec_details\("},
     "libraries": {"patch": r"[+-] +def libs\("},
     "headers": {"patch": r"[+-] +def headers\("},
-    "stand-alone-tests": {"patch": r"[+-] +def test\("},
+    "stand-alone-tests": {"patch": r"[+-] +def test[_]?.*\("},
     #
     # Core spack
     #


### PR DESCRIPTION
This PR updates the regular expression for the stand-alone tests label to pick up changes to methods that use the new naming convention (i.e., methods starting`test_`).