### PR TITLE
Remove unrecognized cli argument from buildcache command

### DIFF
--- a/spackbot/workers.py
+++ b/spackbot/workers.py
@@ -651,7 +651,6 @@ async def update_mirror_index(base_mirror_url):
                     "-d",
                     "buildcache",
                     "update-index",
-                    "--mirror-url",
                     f"{stack_mirror_url}",
                 ],
             )


### PR DESCRIPTION
I've noticed that pipelines are generated a lot of unnecessary jobs (rebuild jobs that find there's nothing to rebuild).  This led me to notice that none of the stacks within the `shared_pr_mirror` have an index, and from there that the `spack buildcache update-index` command used here is out of date.

I'm not sure why even with the `-d` argument to the command, we don't see any errors in the `lworkers` log, but this PR should fix the issue updating the mirror indices so pipelines can stop generating those unnecessary jobs.