### PR TITLE
Update the worker image to reference Spack for style requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 EXPOSE 8080
 

--- a/spackbot/routes.py
+++ b/spackbot/routes.py
@@ -19,7 +19,6 @@ logger = helpers.get_logger(__name__)
 
 
 class SpackbotRouter(routing.Router):
-
     """
     Custom router to handle common interactions for spackbot
     """

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.7
+FROM python:3.9
 
+ADD https://raw.githubusercontent.com/spack/spack/refs/heads/develop/.github/workflows/requirements/style/requirements.txt /source/style-requirements.txt
 COPY workers/requirements.txt /source/requirements.txt
 
 RUN pip3 install --upgrade pip setuptools wheel && \
-    pip3 install -r /source/requirements.txt
+    pip3 install -r /source/requirements.txt && \
+    pip3 install -r /source/style-requirements.txt
 
 COPY workers/install_aws.sh /source/install_aws.sh
 

--- a/workers/requirements.txt
+++ b/workers/requirements.txt
@@ -4,10 +4,3 @@ gidgethub
 python_dotenv
 rq
 sh
-
-# Add these so we don't wait for install
-mypy
-flake8
-isort
-black
-clingo


### PR DESCRIPTION
Update the image for spack-bot web service and spackbot-workers to match the expected development environment for Spack.

Latest Spack environment is using ubuntu:22 -> python 3.9.

Instead of relying on spackbot encoded requirements for the style check, directly fetch the style check requirements from spack/develop