### PR TITLE
fix builtin path

### DIFF
--- a/spackbot/handlers/labels.py
+++ b/spackbot/handlers/labels.py
@@ -40,11 +40,11 @@ label_patterns = {
     # Package status
     #
     "new-package": {
-        "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
+        "filename": r"^var/spack/repos/spack_repo/builtin/packages/[^/]+/package.py$",
         "status": r"^added$",
     },
     "update-package": {
-        "filename": r"^var/spack/repos/builtin/packages/[^/]+/package.py$",
+        "filename": r"^var/spack/repos/spack_repo/builtin/packages/[^/]+/package.py$",
         "status": [r"^modified$", r"^renamed$"],
     },
     #
@@ -152,7 +152,7 @@ async def add_labels(event, gh):
 
         # Add our own "package" attribute to the file, if it's a package
         match = re.match(
-            r"var/spack/repos/builtin/packages/([^/]+)/package.py$", filename
+            r"var/spack/repos/spack_repo/builtin/packages/([^/]+)/package.py$", filename
         )
         file["package"] = match.group(1) if match else ""
 

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -282,4 +282,3 @@ def s3_parse_url(url, default_bucket="spack-binaries-prs", default_prefix="dummy
         )
 
     return parsed
-

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -4,20 +4,21 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import aiohttp
 import contextlib
+import gidgethub
 import json
 import logging
 import os
 import re
 import tempfile
+
 from datetime import datetime
 from io import StringIO
-from urllib.parse import urlparse
-from urllib.request import HTTPHandler, Request, build_opener
-
-import aiohttp
-import gidgethub
 from sh import ErrorReturnCode
+from urllib.request import HTTPHandler, Request, build_opener
+from urllib.parse import urlparse
+
 
 """Shared function helpers that can be used across routes"
 """
@@ -281,3 +282,4 @@ def s3_parse_url(url, default_bucket="spack-binaries-prs", default_prefix="dummy
         )
 
     return parsed
+

--- a/spackbot/helpers.py
+++ b/spackbot/helpers.py
@@ -4,21 +4,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import aiohttp
 import contextlib
-import gidgethub
 import json
 import logging
 import os
 import re
 import tempfile
-
 from datetime import datetime
 from io import StringIO
-from sh import ErrorReturnCode
-from urllib.request import HTTPHandler, Request, build_opener
 from urllib.parse import urlparse
+from urllib.request import HTTPHandler, Request, build_opener
 
+import aiohttp
+import gidgethub
+from sh import ErrorReturnCode
 
 """Shared function helpers that can be used across routes"
 """
@@ -32,7 +31,7 @@ gitlab_spack_project_url = os.environ.get(
     "GITLAB_SPACK_PROJECT_URL", "https://gitlab.spack.io/api/v4/projects/2"
 )
 
-package_path = r"^var/spack/repos/builtin/packages/(\w[\w-]*)/package.py$"
+package_path = r"^var/spack/repos/spack_repo/builtin/packages/(\w[\w-]*)/package.py$"
 
 # Bot name can be modified in the environment
 botname = os.environ.get("SPACKBOT_NAME", "@spackbot")


### PR DESCRIPTION
due to https://github.com/spack/spack/pull/49275, builtin packages are
now located at `var/spack/repos/spack_repo/builtin`

Once the package repo is fully split from core, we'll probably need a
follow-on PR to change the `spack_develop_url`  in `spackbot/helpers.py`